### PR TITLE
Don't require URL value

### DIFF
--- a/example.typ
+++ b/example.typ
@@ -5,11 +5,11 @@
   name: configuration.contacts.name,
   position: configuration.position,
   links: (
-    (name: "email", link: "mailto:"+ configuration.contacts.email),
+    (name: "email", link: "mailto:"+ configuration.contacts.email, display: configuration.contacts.email),
     (name: "website", link: configuration.contacts.website.url, display: configuration.contacts.website.displayText),
     (name: "github", link: configuration.contacts.github.url, display: configuration.contacts.github.displayText),
     (name: "linkedin", link: configuration.contacts.linkedin.url, display: configuration.contacts.linkedin.displayText),
-    (name: "location", link: "", display: configuration.contacts.address)
+    (name: "location", link: configuration.contacts.location, display: configuration.contacts.address)
   ),
   tagline: (configuration.tagline),
   [

--- a/vantage-typst.typ
+++ b/vantage-typst.typ
@@ -17,10 +17,14 @@
   services.map(service => {
       icon(service.name)
 
-      if "display" in service.keys() {
-        link(service.link)[#{service.display}]
+      if service.link == "" and "display" not in service.keys() { return }
+
+      let content = if "display" in service.keys() { service.display } else { service.link }
+
+      if service.link != "" {
+        link(service.link)[#content]
       } else {
-        link(service.link)
+        content
       }
     }).join(h(10pt))
   [


### PR DESCRIPTION
An empty string for the location URL throws an error.
Using typst version 0.14.2 (b33de9de).

```
error: URL must not be empty
   ┌─ vantage-typst.typ:21:13
   │
21 │         link(service.link)[#{service.display}]
   │              ^^^^^^^^^^^^

help: error occurred in this call of function `findMe`
    ┌─ vantage-typst.typ:130:2
    │
130 │   findMe(links)
    │   ^^^^^^^^^^^^^

help: error occurred in this call of function `vantage`
   ┌─ example.typ:4:1
   │  
 4 │   #vantage(
   │ ╭──^
 5 │ │   name: configuration.contacts.name,
 6 │ │   position: configuration.position,
 7 │ │   links: (
   · │
81 │ │   ]
82 │ │ )
   │ ╰─^

```